### PR TITLE
Use Prism parser for Sorbet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,14 +80,14 @@ GEM
     rubocop-shopify (2.18.0)
       rubocop (~> 1.62)
     ruby-progressbar (1.13.0)
-    sorbet (0.6.12945)
-      sorbet-static (= 0.6.12945)
-    sorbet-runtime (0.6.12945)
-    sorbet-static (0.6.12945-universal-darwin)
-    sorbet-static (0.6.12945-x86_64-linux)
-    sorbet-static-and-runtime (0.6.12945)
-      sorbet (= 0.6.12945)
-      sorbet-runtime (= 0.6.12945)
+    sorbet (0.6.13055)
+      sorbet-static (= 0.6.13055)
+    sorbet-runtime (0.6.13055)
+    sorbet-static (0.6.13055-universal-darwin)
+    sorbet-static (0.6.13055-x86_64-linux)
+    sorbet-static-and-runtime (0.6.13055)
+      sorbet (= 0.6.13055)
+      sorbet-runtime (= 0.6.13055)
     spoom (1.7.11)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
@@ -173,11 +173,11 @@ CHECKSUMS
   rubocop-rake (0.7.1) sha256=3797f2b6810c3e9df7376c26d5f44f3475eda59eb1adc38e6f62ecf027cbae4d
   rubocop-shopify (2.18.0) sha256=dafa25e5617ce4600ff86b1de3d5b78e43ab3d58cc5729df38e492b8e10294eb
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  sorbet (0.6.12945) sha256=40fd8c121f7e9ded24462daf757707dc588889646daed478a47b7359d2969d84
-  sorbet-runtime (0.6.12945) sha256=3ddd992650437557fb87deb13c94d7250aeeab326812e7a863dfd4955f0758f3
-  sorbet-static (0.6.12945-universal-darwin) sha256=766038d71e0ab7f8a60eb298b742d4e5fb9bd364034c651443f825fb4d61f11e
-  sorbet-static (0.6.12945-x86_64-linux) sha256=c393afe666e41d51afa111b6913b572aee6032f3a77546ea5fb1b690906fcc25
-  sorbet-static-and-runtime (0.6.12945) sha256=6a0ae4ac59ddc874e9438ff6e0f23b4eb78569c6d412ced4e043f3a6db6b44d0
+  sorbet (0.6.13055) sha256=5f5e8f37c13c281fa2b2f95e261d2e531d8331ddcc8e2dd8c4f16457935872ec
+  sorbet-runtime (0.6.13055) sha256=c8ae8c81310e0a28d290b11f44ddca59659b7d7f13752c0ef5d16964bbb84d18
+  sorbet-static (0.6.13055-universal-darwin) sha256=649c8e79a443be85318922f9ecbb46be72f6c585443f4440c4ec0fb1737c86e8
+  sorbet-static (0.6.13055-x86_64-linux) sha256=01b6941106dadb334a87d56afce1a5fffcdcf5de21c718858975b666a624bfb1
+  sorbet-static-and-runtime (0.6.13055) sha256=050f9ef00dda7578a2de729cf3a1accf3111eca23671e3a5a9adfd563d197fb7
   spoom (1.7.11) sha256=4e27384af6d3fde5aadc0287c51e6f76c0802259cbb3b6a67603bf718352f4cf
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   tapioca (0.17.10) sha256=880a682ca8314f798dd09e9f104134fbf1a713c13be51f7dd4741dd434e6471b

--- a/sorbet/config
+++ b/sorbet/config
@@ -6,3 +6,4 @@
 --enable-experimental-requires-ancestor
 --suppress-payload-superclass-redefinition-for=RDoc::Markup::Heading
 --suppress-error-code=5022
+--parser=prism


### PR DESCRIPTION
Adds `--parser=prism` to `sorbet/config` to use the Prism parser instead of the legacy Whitequark parser.