### PR TITLE
fix: delegate Module#abstract! to super implementation if one exists

### DIFF
--- a/lib/type_toolkit/ext/module.rb
+++ b/lib/type_toolkit/ext/module.rb
@@ -4,4 +4,9 @@ class Module
   def interface!
     TypeToolkit.make_interface!(self)
   end
+
+  def abstract!
+    super if defined?(super)
+    TypeToolkit.make_abstract!(self)
+  end
 end

--- a/lib/type_toolkit/interface.rb
+++ b/lib/type_toolkit/interface.rb
@@ -19,6 +19,14 @@ module TypeToolkit
       mod.extend(TypeToolkit::MethodDefRecorder)
       mod.extend(TypeToolkit::HasAbstractMethods)
     end
+
+    #: (Class[top]) -> void
+    def make_abstract!(klass)
+      klass.extend(TypeToolkit::DSL)
+      klass.extend(TypeToolkit::MethodDefRecorder)
+      klass.extend(TypeToolkit::HasAbstractMethods)
+      klass.include(TypeToolkit::AbstractInstanceMethodReceiver)
+    end
   end
 
   # This module is extended onto any module that represents an interface.

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -341,6 +341,42 @@ module TypeToolkit
       end
     end
 
+    describe "abstract!" do
+      it "makes a class abstract" do
+        klass = Class.new do
+          abstract!
+
+          abstract def my_method = assert_never_called!
+        end
+
+        assert klass.abstract_method?(:my_method)
+      end
+
+      it "delegates to an existing abstract! if one is defined" do
+        called = false
+
+        # Simulate another gem (e.g. Rails) defining abstract! on Object,
+        # which is Module's superclass. Module#abstract! should call super to reach it.
+        Object.define_method(:abstract!) { called = true }
+
+        klass = Class.new
+        klass.abstract!
+
+        assert called, "expected the other abstract! to have been called via super"
+        assert_respond_to klass, :abstract_instance_methods
+      ensure
+        Object.remove_method(:abstract!)
+      end
+
+      it "works when no parent abstract! exists" do
+        klass = Class.new do
+          abstract!
+        end
+
+        assert_respond_to klass, :abstract_instance_methods
+      end
+    end
+
     describe "A class that fully implements the interface, partially via inheritance" do
       before do
         @class = PartiallyInheritsItsImpl


### PR DESCRIPTION
# Summary
- Add `Module#abstract!` with `super if defined?(super)` to delegate to any existing `abstract!` implementation (e.g. Rail's 'AbstractController::Base.abstract!`) before running type_toolkit's own setup
- Add `TypeToolkit.make_abstract!` to set up abstract class support

Fixes #10 

## Tests
  - [x] Existing test suite passes (45 tests, 110 assertions)
  - [x] New test verifies `super` delegates to an existing `abstract!` when one is defined
  - [x] New test verifies `abstract!` works normally when no parent implementation exists
  - [x] New test verifies basic `abstract!` functionality (marking methods as abstract)