### PR TITLE
Add test coverage for interface! rejecting classes

### DIFF
--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -53,6 +53,36 @@ module TypeToolkit
     end
 
     describe "An interface" do
+      describe "interface!" do
+        it "raises when called on a class" do
+          error = assert_raises(TypeError) do
+            Class.new do
+              interface!
+            end
+          end
+
+          assert_equal "Classes can't be interfaces. Did you mean to make it `abstract` instead?", error.message
+        end
+
+        it "raises when called on a module's singleton class" do
+          error = assert_raises(TypeError) do
+            Module.new do
+              class << self
+                interface!
+              end
+            end
+          end
+
+          assert_equal "Classes can't be interfaces. Did you mean to make it `abstract` instead?", error.message
+        end
+
+        it "does not raise when called on a module" do
+          Module.new do
+            interface!
+          end
+        end
+      end
+
       describe ".abstract macro" do
         it "returns the method name" do
           test_context = self


### PR DESCRIPTION
## Summary

`interface!` already raises `TypeError` when called on a `Class`:

```ruby
class MyClass
  interface! # already raises TypeError
end
```

This also already covers the `class << self` case from the issue, since a module's singleton class is itself an instance of `Class`:

```ruby
module MyInterface
  class << self
    interface! # already raises TypeError, since MyInterface.singleton_class is a Class
  end
end
```

This existing guard (in `TypeToolkit.make_interface!`) wasn't covered by any spec, so it was easy to lose track of. This PR adds specs for both raising cases, plus a sanity check that `interface!` still works normally on a plain module.

Fixes #4

## Test plan
- [x] `bundle exec rake test` — 92 runs, 0 failures
- [x] `bundle exec rake rubocop` — no offenses
- [x] `bundle exec rake typecheck` — no errors