### PR TITLE
Add Module#private_constants block for concise private constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ EmailNotifier.new.send_notification("Hello, world!") # ❌ TypeToolkit::Abstract
 # => Abstract method #send_notification was never implemented.
 ```
 
+### Private constants
+
+Unlike methods, constants don't respect `private`/`public` regions, so making one private normally means repeating its name in a separate `private_constant` call:
+
+```ruby
+class Configuration
+  DEFAULT_TIMEOUT = 30
+  private_constant :DEFAULT_TIMEOUT
+end
+```
+
+Type Toolkit's `private_constants` marks every constant defined within its block as private, so you don't have to repeat yourself:
+
+```ruby
+class Configuration
+  private_constants do
+    DEFAULT_TIMEOUT = 30
+  end
+end
+
+Configuration::DEFAULT_TIMEOUT # ❌ NameError
+# => private constant Configuration::DEFAULT_TIMEOUT referenced
+```
+
 ## Guiding Principles
 
 ### Blazingly fast™

--- a/lib/type_toolkit/ext/module.rb
+++ b/lib/type_toolkit/ext/module.rb
@@ -1,7 +1,33 @@
+# typed: true
 # frozen_string_literal: true
 
 class Module
   def interface!
     TypeToolkit.make_interface!(self)
+  end
+
+  # Marks every constant defined directly within the block as private.
+  #
+  # Constants don't respect `private`/`public` regions the way methods do, so making one private
+  # normally means repeating its name in a separate `private_constant` call. This bundles that up
+  # into a single block, so you don't have to.
+  #
+  # Example:
+  #
+  #   class Configuration
+  #     private_constants do
+  #       DEFAULT_TIMEOUT = 30
+  #     end
+  #   end
+  #
+  #   Configuration::DEFAULT_TIMEOUT
+  #   # => NameError: private constant Configuration::DEFAULT_TIMEOUT referenced
+  #
+  #: () { () -> void } -> void
+  def private_constants(&block)
+    constants_before = constants(false)
+    yield
+    new_constants = constants(false) - constants_before
+    new_constants.each { |constant_name| private_constant(constant_name) }
   end
 end

--- a/spec/private_constants_spec.rb
+++ b/spec/private_constants_spec.rb
@@ -1,0 +1,61 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module TypeToolkit
+  class PrivateConstantsSpec < Minitest::Spec
+    class WithPrivateConstants
+      private_constants do
+        SECRET = 123
+        ANOTHER_SECRET = 456
+      end
+
+      PUBLIC_CONSTANT = 789
+
+      class << self
+        def secret = SECRET
+      end
+    end
+
+    class WithNestedPrivateConstant
+      private_constants do
+        class Inner
+        end
+      end
+    end
+
+    describe "Module#private_constants" do
+      it "marks every constant defined within the block as private" do
+        assert_raises(NameError) { WithPrivateConstants::SECRET }
+        assert_raises(NameError) { WithPrivateConstants::ANOTHER_SECRET }
+      end
+
+      it "still allows the defining scope to reference the constant unqualified" do
+        assert_equal 123, WithPrivateConstants.secret
+      end
+
+      it "does not affect constants defined outside the block" do
+        assert_equal 789, WithPrivateConstants::PUBLIC_CONSTANT
+      end
+
+      it "works for constants defined via the `class`/`module` keywords, not just `=`" do
+        assert_raises(NameError) { WithNestedPrivateConstant::Inner }
+      end
+
+      it "does not raise when the block defines no new constants" do
+        WithPrivateConstants.private_constants {}
+      end
+
+      it "propagates exceptions raised inside the block" do
+        assert_raises(RuntimeError) do
+          Module.new do
+            private_constants do
+              raise "boom"
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Constants don't respect `private`/`public` regions the way methods do, so making one private normally means repeating its name in a separate `private_constant` call:

```ruby
class Configuration
  DEFAULT_TIMEOUT = 30
  private_constant :DEFAULT_TIMEOUT
end
```

This implements the `private_constants do ... end` API suggested in the issue: every constant defined directly within the block is automatically marked private via `private_constant` once the block finishes.

```ruby
class Configuration
  private_constants do
    DEFAULT_TIMEOUT = 30
  end
end

Configuration::DEFAULT_TIMEOUT # ❌ NameError: private constant Configuration::DEFAULT_TIMEOUT referenced
```

It only marks constants introduced *during* the block (diffing `constants(false)` before/after), so pre-existing constants are left untouched, and it's a no-op if the block doesn't define any new constants (avoiding Ruby's "private_constant with no argument is just ignored" warning).

Added to `lib/type_toolkit/ext/module.rb`, next to `interface!`, since it's a similar small Module-level extension. Also added a README section under "Tools".

## Test plan
- [x] `bundle exec rake test` — 95 runs, 0 failures
- [x] `bundle exec rake rubocop` — no offenses
- [x] `bundle exec rake typecheck` / `typecheck_prism` — no errors
- New specs in `spec/private_constants_spec.rb` cover: constants defined via `=` and via `class`/`module` keywords being made private, constants outside the block staying public, unqualified access still working from the defining scope, a no-op empty block, and exceptions inside the block propagating normally

Fixes #9