### PR TITLE
Allow abstract methods to be implemented via method_missing

### DIFF
--- a/lib/type_toolkit/abstract_method_receiver.rb
+++ b/lib/type_toolkit/abstract_method_receiver.rb
@@ -20,15 +20,28 @@ module TypeToolkit
     # This `#method_missing` is hit when calling a potentially abstract method on an instance
     # E.g. TheClass.new.maybe_abstract_method
     #
+    # We call `super` first, so that another `method_missing` further up the ancestor chain
+    # gets a chance to provide a dynamic implementation of the abstract method.
+    # Only if nothing handled the call do we translate the resulting `NoMethodError`
+    # into an `AbstractMethodNotImplementedError`.
+    #
     # (Symbol, ...) -> untyped
     def method_missing(method_name, ...)
+      super
+    rescue NoMethodError => e
+      # A `NoMethodError` for a *different* method was raised from within a dynamic
+      # implementation of this method. That's a real error, not an unimplemented abstract method.
+      raise unless e.name == method_name
+
       c = self.class #: as Class[top] & HasAbstractMethods
 
       if c.abstract_method_declared?(method_name)
-        raise AbstractMethodNotImplementedError.new(method_name:)
+        # `cause: nil` hides the unactionable "undefined method" error, which would
+        # otherwise be noise underneath the more precise error we raise here.
+        raise AbstractMethodNotImplementedError.new(method_name:), cause: nil
       end
 
-      super
+      raise
     end
 
     #: (Symbol, ?bool) -> bool

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -52,6 +52,43 @@ module TypeToolkit
       def m2 = "PartiallyInheritsItsImpl#m2"
     end
 
+    # A class that provides a dynamic implementation of `m1` via `method_missing`, for `MethodMissingImpl`.
+    class MethodMissingParent
+      def method_missing(method_name, ...)
+        return super unless method_name == :m1
+
+        "MethodMissingParent#m1"
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        method_name == :m1 || super
+      end
+    end
+
+    # A class that implements `m1` dynamically, via the `method_missing` it inherits.
+    class MethodMissingImpl < MethodMissingParent
+      include SimpleInterface
+      # Does not provide an implementation for `m2`
+    end
+
+    # A class whose dynamic implementation of `m1` itself calls an undefined method.
+    class BrokenMethodMissingParent
+      def method_missing(method_name, ...)
+        return super unless method_name == :m1
+
+        Object.new.some_undefined_helper
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        method_name == :m1 || super
+      end
+    end
+
+    # A class whose inherited dynamic implementation of `m1` is broken.
+    class BrokenMethodMissingImpl < BrokenMethodMissingParent
+      include SimpleInterface
+    end
+
     describe "An interface" do
       describe ".abstract macro" do
         it "returns the method name" do
@@ -398,6 +435,37 @@ module TypeToolkit
           assert_equal [], @class.abstract_instance_methods
           assert_equal [], @class.abstract_instance_methods(true)
           assert_equal [], @class.abstract_instance_methods(false)
+        end
+      end
+    end
+
+    describe "A class that implements the interface via method_missing" do
+      before do
+        @x = MethodMissingImpl.new
+      end
+
+      describe "calling an abstract method implemented via method_missing" do
+        it "calls the dynamic implementation" do
+          assert_respond_to @x, :m1
+          assert_equal "MethodMissingParent#m1", @x.m1
+        end
+      end
+
+      describe "calling an unimplemented abstract method" do
+        it "raises AbstractMethodNotImplementedError, without a NoMethodError cause" do
+          e = assert_abstract { @x.m2 }
+
+          # The internal `NoMethodError` (from the call reaching `BasicObject#method_missing`)
+          # is unactionable noise, so it should not be exposed as the `cause`.
+          assert_nil e.cause
+        end
+      end
+
+      describe "calling an abstract method whose dynamic implementation is broken" do
+        it "propagates the NoMethodError raised inside the dynamic implementation" do
+          e = assert_raises(NoMethodError) { BrokenMethodMissingImpl.new.m1 }
+
+          assert_equal :some_undefined_helper, e.name
         end
       end
     end


### PR DESCRIPTION
Closes #11

### Problem

`AbstractInstanceMethodReceiver#method_missing` raised `AbstractMethodNotImplementedError` *before* calling `super`, so a `method_missing` defined further up the ancestor chain (e.g. on a superclass) never got the chance to provide a dynamic implementation of an abstract method:

```ruby
module MyInterface
  interface!

  abstract def demo; end
end

class Parent
  def method_missing(m, ...)
    return super unless m == :demo

    "dynamic #demo"
  end
end

class Child < Parent
  include MyInterface
end

Child.new.demo # raised AbstractMethodNotImplementedError, now returns "dynamic #demo"
```

### Approach

As suggested in https://github.com/Shopify/type_toolkit/issues/11#issuecomment-3936985663: call `super` first, and only translate the resulting `NoMethodError` into an `AbstractMethodNotImplementedError` if nothing handled the call.

Two refinements over the sketch in the issue:

- The `NoMethodError` is only translated when `e.name == method_name`. A `NoMethodError` for a *different* method — e.g. raised from inside a broken dynamic implementation of the abstract method — is a real error and propagates unchanged, instead of being misreported as "abstract method never implemented".
- The translated error is raised with `cause: nil` (as in the issue's sketch), since the underlying "undefined method" error is unactionable noise beneath the more precise error.

I went with rescuing `NoMethodError` rather than checking `respond_to_missing?` first, per the reasoning in the issue: lots of code overrides `method_missing` without overriding `respond_to_missing?`.

### Tests

Three new specs in `interface_spec.rb`:

- an abstract method implemented via an inherited `method_missing` can be called
- an unimplemented abstract method still raises `AbstractMethodNotImplementedError`, with no `NoMethodError` cause attached
- a `NoMethodError` raised *inside* a dynamic implementation propagates as-is

All local checks pass: `rake typecheck` (incl. Prism), `rake test` (92 runs, 0 failures), `rake rubocop`, `bin/tapioca gem --verify`, `bin/tapioca check-shims`.

Note: #11 had an assignment request from April that was never assigned and has no linked PR — happy to step aside if that work is still in flight.
